### PR TITLE
Update merge.js

### DIFF
--- a/merge.js
+++ b/merge.js
@@ -771,7 +771,7 @@ function generateNaturalizedCitizenFile() {
         // ヘッダーとデータレコーダーに分割
         const { header, rows } = parseCSV(text);
         const validCodes = ['A51', 'A52', 'A61', 'A62', 'BE1', 'BE2', 'BF1', 'BF2'];
-        // 出力用のヘッダーを定義する（長いので）
+        // 出力用のヘッダーを定義する
         const OutputHeader = [
             '宛名番号',
             '世帯番号',
@@ -825,8 +825,6 @@ function generateNaturalizedCitizenFile() {
         return [OutputHeader.join(','), ...selectedLines.map(line => line.join(','))].join('\n');
     }
 }
-
-
 
 
 


### PR DESCRIPTION
generateReferencingFile1
→ステップ7（住基照会用ファイル①を出力する処理）に該当するfunctionです。
　転入元都道府県市区町村コードが「99999」かつ
　異動事由コードがA51,A52,A61,A62,BE1,BE2,BF1,BF2のいずれでもない住民を抽出し、
　指定された仕様にファイル形式を整える処理になります

generateNaturalizedCitizenFile
→ステップ8（帰化対象者リストを出力する処理）に該当するfunctionです。
　ステップ7とは逆に、
　転入元都道府県市区町村コードが「99999」ではないかつ
　異動事由コードがA51,A52,A61,A62,BE1,BE2,BF1,BF2のいずれかである住民を抽出し、
　指定された仕様にファイル形式を整える処理になります