### PR TITLE
20240617 doiguchi 1

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,16 +63,16 @@
             <button type="button" onclick="deleteRowsByReason()">中間ファイル⑤を作成する</button>
         </form>
 
-        <h1>5. 「転入元都道府県市区町村コード」の値を「情報提供者機関コード」に変換する</h1>
+        <!--<h1>5. 「転入元都道府県市区町村コード」の値を「情報提供者機関コード」に変換する</h1>
         <form id="csvForm8">
             <label for="file11">中間ファイル⑥をアップロードしてください:</label>
             <input type="file" id="file11" accept=".csv"><br><br>
             <label for="file12">機関コードファイルをアップロードしてください:</label>
             <input type="file" id="file12" accept=".csv"><br><br>
             <button type="button" onclick="ChangeRowsFromInstitutionCode()">中間ファイル⑦を作成する</button>
-        </form>
+        </form>-->
 
-        <h1>6.中間サーバに連携する「税情報無し対象者ファイル」を作成する</h1>
+        <h1>5.中間サーバに連携する「税情報無し対象者ファイル」を作成する</h1>
         <form id="csvForm6">
             <label for="file9">中間ファイル⑤をアップロードして下さい:</label>
             <input type="file" id="file9" accept=".csv"><br><br>
@@ -86,14 +86,14 @@
             <button type="button" onclick="generateTaxInfoInquiryFile()">税情報照会ファイルを作成する</button>
         </form>-->
 
-        <h1>7.住基照会用ファイル①を作成する</h1>
+        <h1>6.住基照会用ファイル①を作成する</h1>
         <form id="csvForm9">
             <label for="file13">中間ファイル⑤をアップロードしてください:</label>
             <input type="file" id="file13" accept=".csv"><br><br>
             <button type="button" onclick="generatePreviousAddressForeignFile()">住基照会用ファイル①を作成する</button>
         </form>
 
-        <h1>8.帰化対象者リストを作成する</h1>
+        <h1>7.帰化対象者リストを作成する</h1>
         <form id="csvForm10">
             <label for="file14">中間ファイル⑤をアップロードしてください:</label>
             <input type="file" id="file14" accept=".csv"><br><br>


### PR DESCRIPTION
修正箇所

handleFile
→除外条件を微修正しました（コード内コメントで記載しています）
　また、各除外条件に当てはまる住民の住民票コードを取得し、
　同住民番号の行を全除外するように修正しています（今までは除外条件に当てはまる住民のみだった）

deleteRowsByReason
→今までは、廃止事由リスト内「廃止理由」カラムが「18」である行を
　宛名番号をキーにして除外する処理でしたが、「21」である行に関して
　「課税区分」を「4（未申告）」として更新する処理を追加しました

また、検証用でStep1（mergeCSV）を編集していますが、こちらはRV不要です。
変更履歴に表示されてしまうと思います、すみません…