### PR TITLE
20240627 doiguchi 1

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
                     <label for="file15">中間ファイル④をアップロードしてください:</label>
                     <input type="file" id="file15" accept=".csv"><br><br>
                     <label for="file16">番号連携照会結果（税情報）ファイルをアップロードしてください:</label>
-                    <input type="file" id="file16" accept=".csv"><br><br>
+                    <input type="file" id="file16" accept=".DAT"><br><br>
                     <button type="button" onclick="updateTaxInfoByInquiryResult()">中間ファイル⑤を作成する</button>
                 </form>
 


### PR DESCRIPTION
### ■新規実装箇所

・**updateTaxInfoByInquiryResult**
　→Step6に対応する処理になります。
　　中間ファイル④（csv）と税情報照会用ファイル（DAT）をインプットとし、税情報照会用ファイルに記載されている「所得割額」「均等割額」から課税区分を判断・中間ファイル④内の該当宛名番号行の「課税区分」カラムを更新します。
　　また、税情報照会用ファイルにヘッダーがないため、ヘッダーを定義し、カラム名として連番を入れたのち、後続処理で必要なカラムのみ固有名称を入力して税情報照会用ファイルの1行目に結合させています。
　　テスト用ファイルは「STEP6」フォルダに格納しました。