### PR TITLE
20240724 doiguchi 1

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
                     <input type="file" id="file25" accept=".csv"><br><br>
                     <label for="file26">国内住登無し住民ファイルをアップロードしてください:</label>
                     <input type="file" id="file26" accept=".csv"><br><br>
-                    <button type="button" onclick="mergePublicFundAccountInfo()">中間ファイル⑨を作成する</button>
+                    <button type="button" onclick="mergeNoDomesticAddressRegistration()">中間ファイル⑨を作成する</button>
                 </form>
 
                 <h1>12.旧宛名番号が存在する住民に関して、旧宛名番号の課税区分と現宛名番号を紐づける</h1>


### PR DESCRIPTION
STEP11対応のfunctionを作成したブランチになります。

### 新規function名：mergeNoDomesticAddressRegistration
中間ファイル⑧と「国内住登無し住民」ファイルをインプットとし、
中間ファイル⑧内の「「国内住登無し住民」ファイルに記載されている宛名番号と一致する行」の「課税区分」カラムの値を「4（未申告）」に更新する処理になります。
基本的には、既に実行済みのSTEP4（廃止事由による行の更新）処理を参考にしました。

よろしくお願いいたします。
