### PR TITLE
20240725 doiguchi 1

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,7 +201,7 @@
                     <input type="file" id="file31" accept=".csv"><br><br>
                     <label for="file32">番号連携照会結果（税情報）ファイルをアップロードしてください:</label>
                     <input type="file" id="file32" accept=".DAT"><br><br>
-                    <button type="button" onclick="updateTaxInfoByInquiryResult()">中間ファイル⑪を作成する</button>
+                    <button type="button" onclick="updateTaxInfoByReInquiryResult()">中間ファイル⑪を作成する</button>
                 </form>
 
                 <h1>15.下記の3ファイルを作成する</h1>


### PR DESCRIPTION
STEP14対応のfunctionを作成したブランチになります。

### 新規function名：updateTaxInfoByReInquiryResult
中間ファイル⑩と番号連携照会結果（DAT）ファイルをインプットとし、
中間ファイル⑩内の対象宛名番号の「課税区分」カラムの値を、番号連携照会結果を参照して更新する処理になります。
STEP6の処理と変わらないのですが、インプットファイル名やアウトプットファイル名が異なるため別functionとして作成しました。

実際の課税区分の更新処理に関してはSTEP6と全く同じであるため、STEP6にて呼び出していたプライベートfunctionの「updateTaxInfoByNonHeaderFile」をグローバルfunctionとして外に出し、STEP14でも呼び出す形としました
（また、「updateTaxInfoByNonHeaderFile」のfunction名が微妙にわかり辛かったため「updateTaxInfoByTaxesNumLinkageFile」に変更しました、STEP6の方でも呼び出しfunction名変更済みです。）

また、余談ですが、一応STEP6の実行当時の出力ファイル（7/1実行分）と、今回新規実装のSTEPでの出力ファイルを比較し、差分が無いことを確認しました（当たり前ですがインプットファイルは同じです）

![image](https://github.com/user-attachments/assets/29b1161c-5ee5-4a03-927a-42ba29f27f4d)

よろしくお願いいたします。