### PR TITLE
20240726 doiguchi 1

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,16 +222,17 @@
                     <button type="button" onclick="updateTaxInfoByReInquiryResult()">中間ファイル⑪を作成する</button>
                 </form>
 
-                <h1>15.下記の3ファイルを作成する</h1>
+                <h1>15.下記の4ファイルを作成する</h1>
                 <ul>
                     <li>ServiceNowにインポートする「給付対象者ファイル」</li>
+                    <li>ServiceNowにインポートする「直接振込対象者ファイル」</li>
                     <li>税情報不明住民リスト</li>
                     <li>中間ファイル⑫</li>
                 </ul>
                 <form id="csvForm22">
                     <label for="file33">中間ファイル⑪をアップロードしてください:</label>
                     <input type="file" id="file33" accept=".csv"><br><br>
-                    <button type="button" onclick="generateFilesforPushTargetImport()">上記3ファイルを作成する</button>
+                    <button type="button" onclick="generateFilesforConfirmationTargetImport()">上記4ファイルを作成する</button>
                 </form>
             </div>
         </div>

--- a/merge.js
+++ b/merge.js
@@ -22,59 +22,9 @@ const BENEFICIARY_FILE = '新たな給付_給付対象者.csv';
 const PUSH_TARGET_FLG_FILE = '新たな給付_直接振込対象者.csv';
 const PUBLIC_ACCOUNT_FILE = '新たな給付_公金受取口座情報.csv';
 const TAX_INFO_MASTER = '税情報マスタ.csv';
+const NO_TAX_INFO_FILE = '税情報無し住民ファイル.csv';
 const NUMBER_OF_DATA_DIVISION = 10000; // 税情報データ分割数
 const NEWLINE_CHAR_CRLF = '\r\n'; // 改行コード：CRLF
-const beneficiaryFileHeader = [
-    '宛名番号',
-    '受給者宛名番号',
-    '氏名',
-    '氏名フリガナ',
-    '生年月日',
-    '性別',
-    '電話番号',
-    '郵便番号',
-    '住所',
-    '方書',
-    '異動元郵便番号',
-    '異動元住所',
-    '異動元方書',
-    '世帯番号',
-    '世帯主宛名番号',
-    '続柄',
-    '郵送対象者フラグ',
-    '通称名',
-    '通称名カナ',
-    'フォーマット種別',
-    '課税区分',
-    '住民カスタム属性',
-    '転入日',
-    '賦課期日居住者フラグ',
-    '照会対象フラグ',
-    '賦課無フラグ',
-    '課税保留フラグ',
-    '租税条約免除フラグ',
-    '生活扶助非課税フラグ',
-    '対象者_課税フラグ',
-    '対象者_市減免後均等割額',
-    '対象者_県減免後均等割額',
-    '扶養主_宛名番号',
-    '扶養主_課税フラグ',
-    '扶養主_市免除後均等割額',
-    '扶養主_県免除後均等割額',
-    '専従主_宛名番号',
-    '専従主_課税フラグ',
-    '専従主_市減免後均等割額',
-    '専従主_県減免後均等割額',
-    '生活扶助認定年月日',
-    '生活扶助廃止年月日',
-    '多子加算対象者フラグ'
-]; // SNにインポートする「給付対象者ファイル」のヘッダー
-const pushTargetFileHeader = [
-    '宛名番号',
-    '直接振込対象者フラグ',
-    '課税区分キー',
-]; // SNにインポートする「直接振込対象者ファイル」のヘッダー
-
 
 // todo カラム不備のエラハン
 /* 0.課税区分を判定するために賦課マスタ・個人基本マスタをマージする処理 */
@@ -2432,7 +2382,7 @@ function generateFilesforPushTargetImport() {
                 throw new Error(`次の列が見つかりませんでした： ${missingColumns.join(', ')}\nファイルを確認してください。`);
             }
 
-            const beneficiaryText = generateBeneficiaryfile(columnIndices, rows);
+            const beneficiaryText = generateBeneficiaryfile(columnIndices, rows, 'push');
             if (!beneficiaryText) {
                 logger.warn('■ファイル名：' + BENEFICIARY_FILE + ' >> 出力対象レコードが存在しませんでした。');
             } else {
@@ -2440,7 +2390,7 @@ function generateFilesforPushTargetImport() {
             }
 
             /* 直接振込対象者ファイルの作成処理 */
-            const pushTargetText = generatePushTargetfile(columnIndices, rows);
+            const pushTargetText = generatePushTargetfile(columnIndices, rows, 'push');
             if (!pushTargetText) {
                 logger.warn('■ファイル名：' + PUSH_TARGET_FLG_FILE + ' >> 出力対象レコードが存在しませんでした。');
             } else {
@@ -2487,216 +2437,216 @@ function generateFilesforPushTargetImport() {
     // onloadイベントを発火
     reader.readAsText(files[0]);
 
-    /**
-    *  口座情報が存在する住民が所属する世帯の世帯員全員を抽出し、ファイル形式を整える処理
-    */
-    function generateBeneficiaryfile(columnIndices, rows) {
-        // 出力用の行を格納するリストを定義する
-        const outputLines = [];
-        // 性別カラムの変換時、中間ファイル⑦内の性別コードが「1」「2」の場合にエラーを出力するため、エラー出力用のリストを定義する
-        const genderErrorAddressNums = [];
-        // 続柄カラムの変換時、中間ファイル⑦内の続柄１が空の場合にエラーを出力するため、エラー出力用のリストを定義する
-        const relationshipErrorAddressNums = [];
-        // 課税区分が「3」の場合、課税対象の住民（＝給付対象になりえない住民）が混ざっているということなので、エラーとして表示する。そのためのリストを定義する
-        const taxClassErrorAddressNums = [];
+    // /**
+    // *  口座情報が存在する住民が所属する世帯の世帯員全員を抽出し、ファイル形式を整える処理
+    // */
+    // function generateBeneficiaryfile(columnIndices, rows) {
+    //     // 出力用の行を格納するリストを定義する
+    //     const outputLines = [];
+    //     // 性別カラムの変換時、中間ファイル⑦内の性別コードが「1」「2」の場合にエラーを出力するため、エラー出力用のリストを定義する
+    //     const genderErrorAddressNums = [];
+    //     // 続柄カラムの変換時、中間ファイル⑦内の続柄１が空の場合にエラーを出力するため、エラー出力用のリストを定義する
+    //     const relationshipErrorAddressNums = [];
+    //     // 課税区分が「3」の場合、課税対象の住民（＝給付対象になりえない住民）が混ざっているということなので、エラーとして表示する。そのためのリストを定義する
+    //     const taxClassErrorAddressNums = [];
 
-        // 口座名義カラム・口座番号カラムが空でない（直接振込対象世帯の世帯主）行を抽出する
-        const filteredLines = rows.filter(line => line[columnIndices[17]] && line[columnIndices[18]]);
-        // 口座名義カラム・口座番号カラムが空でない（直接振込対象世帯の世帯主）行毎に、宛名番号・世帯番号を取得後、出力用リストに追加する処理を行う
-        filteredLines.forEach(line => {
-            const addressNum = line[columnIndices[0]]; // 宛名番号を取得する
-            const householdNum = line[columnIndices[9]]; // 世帯番号を取得する
+    //     // 口座名義カラム・口座番号カラムが空でない（直接振込対象世帯の世帯主）行を抽出する
+    //     const filteredLines = rows.filter(line => line[columnIndices[17]] && line[columnIndices[18]]);
+    //     // 口座名義カラム・口座番号カラムが空でない（直接振込対象世帯の世帯主）行毎に、宛名番号・世帯番号を取得後、出力用リストに追加する処理を行う
+    //     filteredLines.forEach(line => {
+    //         const addressNum = line[columnIndices[0]]; // 宛名番号を取得する
+    //         const householdNum = line[columnIndices[9]]; // 世帯番号を取得する
 
-            // 世帯主行を出力用リストに追加する。その際、「受給者宛名番号」は空に設定する
-            outputLines.push(createOutputLineForBeneficiaryFile(line, columnIndices, ''));
+    //         // 世帯主行を出力用リストに追加する。その際、「受給者宛名番号」は空に設定する
+    //         outputLines.push(createOutputLineForBeneficiaryFile(line, columnIndices, ''));
 
-            // 世帯番号をキーにして、世帯主以外の世帯員レコードを取得する
-            const householdMemberLines = rows.filter(otherLine => otherLine[columnIndices[9]] === householdNum && otherLine !== line);
+    //         // 世帯番号をキーにして、世帯主以外の世帯員レコードを取得する
+    //         const householdMemberLines = rows.filter(otherLine => otherLine[columnIndices[9]] === householdNum && otherLine !== line);
 
-            // 世帯員の行を出力用リストに追加する。その際、「受給者宛名番号」に世帯主の宛名番号を設定する
-            householdMemberLines.forEach(line => {
-                outputLines.push(createOutputLineForBeneficiaryFile(line, columnIndices, addressNum));
-            });
-        });
+    //         // 世帯員の行を出力用リストに追加する。その際、「受給者宛名番号」に世帯主の宛名番号を設定する
+    //         householdMemberLines.forEach(line => {
+    //             outputLines.push(createOutputLineForBeneficiaryFile(line, columnIndices, addressNum));
+    //         });
+    //     });
 
-        /**
-         * 抽出後の行のうち必要なカラムのみを抽出し、出力用の行を作成する処理
-         * @param {Array} line - 出力用の行を作成する元となる行
-         * @param {Array} columnIndices - 出力用の行を作成する元となる行のカラムインデックス
-         * @param {String} addressNum - 出力用の行に設定する「受給者宛名番号」（世帯主の場合は空（''）、他世帯員の場合は世帯主の宛名番号を引数として設定する）
-         * @returns {Array} 必要なカラムのみを抽出し、出力用の行を作成した結果
-        */
-        function createOutputLineForBeneficiaryFile(line, columnIndices, addressNum) {
-            let semiProcessedAddressNum = addressNum;
-            // 引数「addressNum」が空でない場合、15桁の宛名番号に変換する
-            if (addressNum !== '') {
-                semiProcessedAddressNum = addressNum.toString().padStart(15, '0');
-            }
-            // 定数として定義しなおす
-            const processedAddressNum = semiProcessedAddressNum
+    //     /**
+    //      * 抽出後の行のうち必要なカラムのみを抽出し、出力用の行を作成する処理
+    //      * @param {Array} line - 出力用の行を作成する元となる行
+    //      * @param {Array} columnIndices - 出力用の行を作成する元となる行のカラムインデックス
+    //      * @param {String} addressNum - 出力用の行に設定する「受給者宛名番号」（世帯主の場合は空（''）、他世帯員の場合は世帯主の宛名番号を引数として設定する）
+    //      * @returns {Array} 必要なカラムのみを抽出し、出力用の行を作成した結果
+    //     */
+    //     function createOutputLineForBeneficiaryFile(line, columnIndices, addressNum) {
+    //         let semiProcessedAddressNum = addressNum;
+    //         // 引数「addressNum」が空でない場合、15桁の宛名番号に変換する
+    //         if (addressNum !== '') {
+    //             semiProcessedAddressNum = addressNum.toString().padStart(15, '0');
+    //         }
+    //         // 定数として定義しなおす
+    //         const processedAddressNum = semiProcessedAddressNum
 
-            // 性別コードを変換し、エラーがあればエラー出力用リストに対象の宛名番号を追加する
-            let genderCode = convertGenderCode(line[columnIndices[4]]);
-            if (genderCode === '') {
-                genderErrorAddressNums.push(line[columnIndices[0]]);
-            }
+    //         // 性別コードを変換し、エラーがあればエラー出力用リストに対象の宛名番号を追加する
+    //         let genderCode = convertGenderCode(line[columnIndices[4]]);
+    //         if (genderCode === '') {
+    //             genderErrorAddressNums.push(line[columnIndices[0]]);
+    //         }
 
-            // 続柄コードを変換し、エラーがあればエラー出力用リストに対象の宛名番号を追加する
-            let relationshipCode = convertRelationshipCode(line[columnIndices[10]], line[columnIndices[11]], line[columnIndices[12]], line[columnIndices[13]]);
-            if (relationshipCode === '') {
-                relationshipErrorAddressNums.push(line[columnIndices[0]]);
-            }
+    //         // 続柄コードを変換し、エラーがあればエラー出力用リストに対象の宛名番号を追加する
+    //         let relationshipCode = convertRelationshipCode(line[columnIndices[10]], line[columnIndices[11]], line[columnIndices[12]], line[columnIndices[13]]);
+    //         if (relationshipCode === '') {
+    //             relationshipErrorAddressNums.push(line[columnIndices[0]]);
+    //         }
 
-            // 多子加算対象住民に対してフラグを立てる（デフォルト値は「0（多子加算非対象）」を設定する）
-            let semiChildAmountFlg = '0';
-            // 日付比較用に、生年月日カラムの値をdate型にする
-            const birthDate = parseDate(line[columnIndices[3]]);
-            // 日付比較用に、H18(2006).4.2をdate型にする
-            const targetDate = new Date('2006-04-02 00:00:00');
-            // 多子加算判定を実施する（世帯主（続柄１が「02」）ではないかつ、生年月日がH18(2006).4.2以降である場合に多子加算対象者とする）
-            if (line[columnIndices[10]] !== '02' && birthDate >= targetDate) {
-                semiChildAmountFlg = '1';
-            }
-            // 定数として定義しなおす
-            const childAmountFlg = semiChildAmountFlg
+    //         // 多子加算対象住民に対してフラグを立てる（デフォルト値は「0（多子加算非対象）」を設定する）
+    //         let semiChildAmountFlg = '0';
+    //         // 日付比較用に、生年月日カラムの値をdate型にする
+    //         const birthDate = parseDate(line[columnIndices[3]]);
+    //         // 日付比較用に、H18(2006).4.2をdate型にする
+    //         const targetDate = new Date('2006-04-02 00:00:00');
+    //         // 多子加算判定を実施する（世帯主（続柄１が「02」）ではないかつ、生年月日がH18(2006).4.2以降である場合に多子加算対象者とする）
+    //         if (line[columnIndices[10]] !== '02' && birthDate >= targetDate) {
+    //             semiChildAmountFlg = '1';
+    //         }
+    //         // 定数として定義しなおす
+    //         const childAmountFlg = semiChildAmountFlg
 
-            // 通称名の使用有無を判断する処理（「外国人氏名優先区分」カラムに「3」が入力されている場合、通称名を入力する。デフォルト値は空）
-            let semiNickname = '';
-            let semiNicknameKana = '';
-            // 通称名の使用有無を判断する（「外国人氏名優先区分」カラムに「3」が入力されている場合、通称名を設定する）
-            if (line[columnIndices[22]] == '3') {
-                semiNickname = line[columnIndices[14]]; // 住基内「外国人通称名」カラムの値を入力
-                semiNicknameKana = line[columnIndices[15]]; // 住基内「外国人カナ通称名」カラムの値を入力
-            }
-            // 定数として定義しなおす
-            const nickname = semiNickname;
-            const nicknameKana = semiNicknameKana;
+    //         // 通称名の使用有無を判断する処理（「外国人氏名優先区分」カラムに「3」が入力されている場合、通称名を入力する。デフォルト値は空）
+    //         let semiNickname = '';
+    //         let semiNicknameKana = '';
+    //         // 通称名の使用有無を判断する（「外国人氏名優先区分」カラムに「3」が入力されている場合、通称名を設定する）
+    //         if (line[columnIndices[22]] == '3') {
+    //             semiNickname = line[columnIndices[14]]; // 住基内「外国人通称名」カラムの値を入力
+    //             semiNicknameKana = line[columnIndices[15]]; // 住基内「外国人カナ通称名」カラムの値を入力
+    //         }
+    //         // 定数として定義しなおす
+    //         const nickname = semiNickname;
+    //         const nicknameKana = semiNicknameKana;
 
-            // インプット内「課税区分」の値を参照し、日本語化した文字列（「非課税対象」「均等割対象」）を、アウトプットの「住民カスタム属性」に出力する処理
-            const inputTaxClass = String(line[columnIndices[23]]); // 判定で数回使用するため、定数として定義しておく
-            let outputTaxClass = ''; // 出力用の変数を定義する
+    //         // インプット内「課税区分」の値を参照し、日本語化した文字列（「非課税対象」「均等割対象」）を、アウトプットの「住民カスタム属性」に出力する処理
+    //         const inputTaxClass = String(line[columnIndices[23]]); // 判定で数回使用するため、定数として定義しておく
+    //         let outputTaxClass = ''; // 出力用の変数を定義する
 
-            // インプットファイル内「名義人氏名」カラムに値が入力されている（＝プッシュ対象世帯の世帯主である）場合のみ、課税区分を判定する処理を行う
-            if (line[columnIndices[17]]) {
-                // 以下、課税区分の値を参照し、日本語化した文字列を変数に格納する処理
-                if (inputTaxClass === '1') {
-                    outputTaxClass = '非課税対象';
-                }
-                else if (inputTaxClass === '2') {
-                    outputTaxClass = '均等割対象';
-                }
-                else if (inputTaxClass === '3') {
-                    // 課税区分が「3」の場合、課税対象の住民（＝給付対象になりえない住民）が混ざっているということなので、エラーとして表示する
-                    taxClassErrorAddressNums.push(line[columnIndices[0]]);
-                }
-                else if (inputTaxClass === '4') {
-                    outputTaxClass = '確認書対象';
-                }
-            }
+    //         // インプットファイル内「名義人氏名」カラムに値が入力されている（＝プッシュ対象世帯の世帯主である）場合のみ、課税区分を判定する処理を行う
+    //         if (line[columnIndices[17]]) {
+    //             // 以下、課税区分の値を参照し、日本語化した文字列を変数に格納する処理
+    //             if (inputTaxClass === '1') {
+    //                 outputTaxClass = '非課税対象';
+    //             }
+    //             else if (inputTaxClass === '2') {
+    //                 outputTaxClass = '均等割対象';
+    //             }
+    //             else if (inputTaxClass === '3') {
+    //                 // 課税区分が「3」の場合、課税対象の住民（＝給付対象になりえない住民）が混ざっているということなので、エラーとして表示する
+    //                 taxClassErrorAddressNums.push(line[columnIndices[0]]);
+    //             }
+    //             else if (inputTaxClass === '4') {
+    //                 outputTaxClass = '確認書対象';
+    //             }
+    //         }
 
-            return [
-                // 以下、テンプレートのカラム  
-                line[columnIndices[0]].toString().padStart(15, '0'), // 宛名番号（15桁に変換する）
-                processedAddressNum, // 受給者宛名番号（世帯主の場合は空、他世帯員の場合は世帯主の宛名番号を15桁に変換した番号を設定する）
-                line[columnIndices[1]] || line[columnIndices[16]],// 漢字氏名（漢字氏名が無い場合は英字氏名を入力する）
-                line[columnIndices[2]], // カナ氏名
-                separateDate(line[columnIndices[3]], '/'), // 生年月日（「yyyy/mm/dd」形式に変換する）
-                genderCode, // 性別
-                excludeHyphen(line[columnIndices[5]]), // 電話番号（ハイフンを除去する）
-                excludeHyphen(line[columnIndices[6]]), // 郵便番号（ハイフンを除去する）
-                line[columnIndices[7]], // 住所
-                line[columnIndices[8]], // 方書
-                '', // 異動元郵便番号
-                '', // 異動元住所
-                '', // 異動元方書
-                line[columnIndices[9]].toString().padStart(15, '0'), // 世帯番号
-                '', // 世帯主宛名番号（世帯主行は空にする）
-                relationshipCode, // 続柄
-                '1', // 郵送対象者フラグ（郵送対象者のため「1」を設定）
-                nickname, // 外国人通称名
-                nicknameKana, // 外国人カナ通称名
-                '非課税均等割確認書', // フォーマット種別（固定値）
-                'R6S1SBS', // 課税区分（固定値）
-                outputTaxClass, // 住民カスタム属性（「課税区分」の値を参照し、日本語化した文字列を入力する）
-                // 以下、非課税・均等割特有のカラム
-                '', // 転入日
-                '', // 賦課期日居住者フラグ
-                '', // 照会対象フラグ
-                '', // 賦課無フラグ
-                '', // 課税保留フラグ
-                '', // 租税条約免除フラグ
-                '', // 生活扶助非課税フラグ
-                '', // 対象者_課税フラグ
-                '', // 対象者_市減免後均等割額
-                '', // 対象者_県減免後均等割額
-                '', // 扶養主_宛名番号
-                '', // 扶養主_課税フラグ
-                '', // 扶養主_市免除後均等割額
-                '', // 扶養主_県免除後均等割額
-                '', // 専従主_宛名番号
-                '', // 専従主_課税フラグ
-                '', // 専従主_市減免後均等割額
-                '', // 専従主_県減免後均等割額
-                '', // 生活扶助認定年月日
-                '', // 生活扶助廃止年月日
-                childAmountFlg // 多子加算対象者フラグ
-            ];
-        }
+    //         return [
+    //             // 以下、テンプレートのカラム  
+    //             line[columnIndices[0]].toString().padStart(15, '0'), // 宛名番号（15桁に変換する）
+    //             processedAddressNum, // 受給者宛名番号（世帯主の場合は空、他世帯員の場合は世帯主の宛名番号を15桁に変換した番号を設定する）
+    //             line[columnIndices[1]] || line[columnIndices[16]],// 漢字氏名（漢字氏名が無い場合は英字氏名を入力する）
+    //             line[columnIndices[2]], // カナ氏名
+    //             separateDate(line[columnIndices[3]], '/'), // 生年月日（「yyyy/mm/dd」形式に変換する）
+    //             genderCode, // 性別
+    //             excludeHyphen(line[columnIndices[5]]), // 電話番号（ハイフンを除去する）
+    //             excludeHyphen(line[columnIndices[6]]), // 郵便番号（ハイフンを除去する）
+    //             line[columnIndices[7]], // 住所
+    //             line[columnIndices[8]], // 方書
+    //             '', // 異動元郵便番号
+    //             '', // 異動元住所
+    //             '', // 異動元方書
+    //             line[columnIndices[9]].toString().padStart(15, '0'), // 世帯番号
+    //             '', // 世帯主宛名番号（世帯主行は空にする）
+    //             relationshipCode, // 続柄
+    //             '1', // 郵送対象者フラグ（郵送対象者のため「1」を設定）
+    //             nickname, // 外国人通称名
+    //             nicknameKana, // 外国人カナ通称名
+    //             '非課税均等割確認書', // フォーマット種別（固定値）
+    //             'R6S1SBS', // 課税区分（固定値）
+    //             outputTaxClass, // 住民カスタム属性（「課税区分」の値を参照し、日本語化した文字列を入力する）
+    //             // 以下、非課税・均等割特有のカラム
+    //             '', // 転入日
+    //             '', // 賦課期日居住者フラグ
+    //             '', // 照会対象フラグ
+    //             '', // 賦課無フラグ
+    //             '', // 課税保留フラグ
+    //             '', // 租税条約免除フラグ
+    //             '', // 生活扶助非課税フラグ
+    //             '', // 対象者_課税フラグ
+    //             '', // 対象者_市減免後均等割額
+    //             '', // 対象者_県減免後均等割額
+    //             '', // 扶養主_宛名番号
+    //             '', // 扶養主_課税フラグ
+    //             '', // 扶養主_市免除後均等割額
+    //             '', // 扶養主_県免除後均等割額
+    //             '', // 専従主_宛名番号
+    //             '', // 専従主_課税フラグ
+    //             '', // 専従主_市減免後均等割額
+    //             '', // 専従主_県減免後均等割額
+    //             '', // 生活扶助認定年月日
+    //             '', // 生活扶助廃止年月日
+    //             childAmountFlg // 多子加算対象者フラグ
+    //         ];
+    //     }
 
-        // 性別コードによるエラーがあれば例外を投げる
-        if (genderErrorAddressNums.length > 0) {
-            throw new Error('以下の住民の性別カラムに「1」「2」以外の値が入力されています。ファイルの確認をお願いします。\n' + genderErrorAddressNums.join('\n'))
-        }
+    //     // 性別コードによるエラーがあれば例外を投げる
+    //     if (genderErrorAddressNums.length > 0) {
+    //         throw new Error('以下の住民の性別カラムに「1」「2」以外の値が入力されています。ファイルの確認をお願いします。\n' + genderErrorAddressNums.join('\n'))
+    //     }
 
-        // 続柄コードによるエラーがあれば例外を投げる
-        if (relationshipErrorAddressNums.length > 0) {
-            throw new Error('以下の住民の続柄１カラムが空です。ファイルの確認をお願いします。\n' + relationshipErrorAddressNums.join('\n'))
-        }
+    //     // 続柄コードによるエラーがあれば例外を投げる
+    //     if (relationshipErrorAddressNums.length > 0) {
+    //         throw new Error('以下の住民の続柄１カラムが空です。ファイルの確認をお願いします。\n' + relationshipErrorAddressNums.join('\n'))
+    //     }
 
-        // 課税区分が「3（課税対象）」であることによるエラーがあれば例外を投げる
-        if (taxClassErrorAddressNums.length > 0) {
-            throw new Error('以下の住民は課税対象の住民です。ファイルの確認をお願いします。\n' + taxClassErrorAddressNums.join('\n'))
-        }
+    //     // 課税区分が「3（課税対象）」であることによるエラーがあれば例外を投げる
+    //     if (taxClassErrorAddressNums.length > 0) {
+    //         throw new Error('以下の住民は課税対象の住民です。ファイルの確認をお願いします。\n' + taxClassErrorAddressNums.join('\n'))
+    //     }
 
-        // 出力用リストをカンマで結合し、改行で区切られた文字列に変換
-        return formatOutputFile(beneficiaryFileHeader, outputLines, NEWLINE_CHAR_CRLF);
-    }
+    //     // 出力用リストをカンマで結合し、改行で区切られた文字列に変換
+    //     return formatOutputFile(beneficiaryFileHeader, outputLines, NEWLINE_CHAR_CRLF);
+    // }
 
-    /**
-    * 直接振込対象者ファイル（フラグ用ファイル）を作成する処理。対象世帯の世帯主、および世帯員全員「直接振込対象者フラグ」カラムに「1（＝直接振込対象者として設定する）」を設定する
-    */
-    function generatePushTargetfile(columnIndices, rows) {
-        // 出力用の行を格納するリストを定義する
-        const outputLines = [];
+    // /**
+    // * 直接振込対象者ファイル（フラグ用ファイル）を作成する処理。対象世帯の世帯主、および世帯員全員「直接振込対象者フラグ」カラムに「1（＝直接振込対象者として設定する）」を設定する
+    // */
+    // function generatePushTargetfile(columnIndices, rows) {
+    //     // 出力用の行を格納するリストを定義する
+    //     const outputLines = [];
 
-        // 抽出対象の世帯番号の値を収集するためのセットを作成する
-        const beneficiaryHouseholdNumSet = new Set();
+    //     // 抽出対象の世帯番号の値を収集するためのセットを作成する
+    //     const beneficiaryHouseholdNumSet = new Set();
 
-        // 名義人カラム・公金口座番号カラムが空でない（プッシュ対象世帯の世帯主）行の「世帯番号」を収集する
-        rows.forEach((line) => {
-            if (line[columnIndices[17]] && line[columnIndices[18]]) {
-                // 「世帯番号」の値をセットに追加する
-                beneficiaryHouseholdNumSet.add(line[columnIndices[9]]);
-            }
-        });
+    //     // 名義人カラム・公金口座番号カラムが空でない（プッシュ対象世帯の世帯主）行の「世帯番号」を収集する
+    //     rows.forEach((line) => {
+    //         if (line[columnIndices[17]] && line[columnIndices[18]]) {
+    //             // 「世帯番号」の値をセットに追加する
+    //             beneficiaryHouseholdNumSet.add(line[columnIndices[9]]);
+    //         }
+    //     });
 
-        // 収集した世帯番号に属する行（対象世帯員全員）を抽出する
-        const filteredLines = rows.filter((line) => {
-            return beneficiaryHouseholdNumSet.has(line[columnIndices[9]]);
-        });
+    //     // 収集した世帯番号に属する行（対象世帯員全員）を抽出する
+    //     const filteredLines = rows.filter((line) => {
+    //         return beneficiaryHouseholdNumSet.has(line[columnIndices[9]]);
+    //     });
 
-        // 抽出した行のうち必要なカラムのみ出力用リストに追加する
-        filteredLines.forEach(line => {
-            outputLines.push([
-                line[columnIndices[0]].toString().padStart(15, '0'), // 宛名番号
-                '1', // 直接振込対象者フラグ（固定値「1」）
-                'R6S1' // 課税区分キー（固定値「R6S1」）
-            ]);
-        });
+    //     // 抽出した行のうち必要なカラムのみ出力用リストに追加する
+    //     filteredLines.forEach(line => {
+    //         outputLines.push([
+    //             line[columnIndices[0]].toString().padStart(15, '0'), // 宛名番号
+    //             '1', // 直接振込対象者フラグ（固定値「1」）
+    //             'R6S1' // 課税区分キー（固定値「R6S1」）
+    //         ]);
+    //     });
 
-        // フィルタリングされた行を再度カンマで結合し、改行で区切られた文字列に変換
-        return formatOutputFile(pushTargetFileHeader, outputLines, NEWLINE_CHAR_CRLF);
-    }
+    //     // フィルタリングされた行を再度カンマで結合し、改行で区切られた文字列に変換
+    //     return formatOutputFile(pushTargetFileHeader, outputLines, NEWLINE_CHAR_CRLF);
+    // }
 
     /**
     * 口座情報ファイルを作成する処理
@@ -3283,7 +3233,536 @@ function updateTaxInfoByReInquiryResult() {
 }
 
 /* 15.ServiceNowにインポートする「給付対象者ファイル」「直接振込対象者ファイル」、確認書対象者を除外した「中間ファイル⑫」を作成する処理 */
+function generateFilesforConfirmationTargetImport() {
+    // 各ファイルのIDを配列に格納する
+    const fileIds = ['file33'];
+    const { check, file_num, files } = fileCheck(fileIds);
+    if (!check) {
+        return; // ファイル数が足りない場合は処理を終了
+    }
 
+    // ファイル形式をチェック
+    const extensionCheck = fileExtensionCheck(files);
+    if (!extensionCheck) {
+        return; // ファイル名が「.csv」で終わらない場合はエラーを出して処理終了
+    }
+
+    // 「中間ファイル⑦」がインプットされたことを確認する（前方一致で確認）
+    if (!files[0].name.startsWith('中間ファイル⑪')) {
+        alert('アップロードするファイル名を「中間ファイル⑪」から始まるものにして下さい。');
+        return; // ファイル名が「中間ファイル⑪」で始まらない場合はエラーを出して処理終了
+    }
+
+    // 処理開始log
+    logger.info('STEP 15 処理を開始しました');
+    //showLoading();
+
+    // 読み込んだデータをresults配列の対応する位置に保存する
+    const reader = new FileReader();
+    reader.onload = function (e) {
+        try {
+            // 全ての処理が完了したら結果をダウンロードするためのフラグ
+            let beneficiaryTextFlg = false;
+            let pushTargetTextFlg = false;
+            let noTaxInfoTextFlg = false;
+            let midFileTextFlg = false;
+
+            // e.target.result:FileReaderが読み込んだファイルの内容（文字列）
+            let text = e.target.result;
+
+            // 中間ファイル⑪の内容を読み込む
+            const { header, rows } = parseCSV(text);
+
+            /* 給付対象者ファイルの作成処理 */
+            // 給付対象者ファイルの作成に必要なカラムを定義する（後続の3ファイル作成処理でもそのまま使用可能）
+            const requiredColumns = [
+                '宛名番号',
+                '漢字氏名',
+                'カナ氏名',
+                '生年月日',
+                '性別',
+                '電話番号',
+                '現住所郵便番号',
+                '現住所',
+                '現住所方書',
+                '世帯番号',
+                '続柄１',
+                '続柄２',
+                '続柄３',
+                '続柄４',
+                '外国人通称名',
+                '外国人カナ通称名',
+                '英字氏名',
+                '名義人氏名',
+                '口座番号',
+                '店番',
+                '金融機関コード',
+                '預貯金種目コード',
+                '外国人氏名優先区分', // 通称名の使用有無を判定するために必要となる
+                '課税区分' // 「住民カスタム属性」に入力する値の参照として必要となる
+            ];
+            const columnIndices = requiredColumns.map(col => header.indexOf(col));
+            // 足りないカラムをチェック
+            const missingColumns = requiredColumns.filter((col, index) => columnIndices[index] === -1);
+
+            if (missingColumns.length > 0) {
+                throw new Error(`次の列が見つかりませんでした： ${missingColumns.join(', ')}\nファイルを確認してください。`);
+            }
+
+            const beneficiaryText = generateBeneficiaryfile(columnIndices, rows, 'confirmation');
+            if (!beneficiaryText) {
+                logger.warn('■ファイル名：' + BENEFICIARY_FILE + ' >> 出力対象レコードが存在しませんでした。');
+            } else {
+                beneficiaryTextFlg = true;
+            }
+
+            /* 直接振込対象者ファイルの作成処理 */
+            const pushTargetText = generatePushTargetfile(columnIndices, rows, 'confirmation');
+            if (!pushTargetText) {
+                logger.warn('■ファイル名：' + PUSH_TARGET_FLG_FILE + ' >> 出力対象レコードが存在しませんでした。');
+            } else {
+                pushTargetTextFlg = true;
+            }
+
+            /* 税情報が無い住民ファイルの作成処理 */
+            const noTaxInfoText = generateNoTaxInfofile(columnIndices, header, rows);
+            if (!noTaxInfoText) {
+                logger.warn('■ファイル名：' + NO_TAX_INFO_FILE + ' >> 出力対象レコードが存在しませんでした。');
+            } else {
+                noTaxInfoTextFlg = true;
+            }
+
+            /* 中間ファイル⑫の作成処理 */
+            const Midfile12Text = generateMidfile12(columnIndices, header, rows);
+            if (!generateMidfile12) {
+                logger.warn('■ファイル名：' + MIDDLE_FILE_12 + ' >> 出力対象レコードが存在しませんでした。');
+            } else {
+                midFileTextFlg = true;
+            }
+
+            // 各ファイルをダウンロード            
+            if (beneficiaryTextFlg) {
+                downloadCSV(beneficiaryText, BENEFICIARY_FILE);
+            }
+            if (pushTargetTextFlg) {
+                downloadCSV(pushTargetText, PUSH_TARGET_FLG_FILE);
+            }
+            if (noTaxInfoTextFlg) {
+                downloadCSV(noTaxInfoText, NO_TAX_INFO_FILE);
+            }
+            if (midFileTextFlg) {
+                downloadCSV(Midfile12Text, MIDDLE_FILE_12);
+            }
+        } catch (error) {
+            // catchしたエラーを表示
+            logger.error(error);
+        } finally {
+            logger.info('STEP 15 処理を終了しました');
+            //hideLoading();
+        }
+    };
+    // onloadイベントを発火
+    reader.readAsText(files[0]);
+
+    /**
+    * 税情報無しの住民を抽出し、税情報無し住民ファイルを作成する処理
+    */
+    function generateNoTaxInfofile(columnIndices, header, rows) {
+        const filteredLines = rows.filter(line => {
+            const taxClass = line[columnIndices[23]];
+            // 課税区分が空、もしくは「99（＝こちらで便宜上入力した、番号照会エラーの住民）」の場合に抽出する
+            return (taxClass === '' || taxClass === '99');
+        });
+
+        // フィルタリングされた行から必要なカラムを入力する。仕様書が現在連携されていないため、後ほど確認の上で実装する
+        /*const selectedLines = filteredLines.map(line => [
+            line[columnIndices[0]],  // 宛名番号列
+            // 他必要カラムを入力
+        ]);*/
+
+        // フィルタリングされた行を再度カンマで結合し、改行で区切られた文字列に変換
+        return formatOutputFile(header, filteredLines, NEWLINE_CHAR_CRLF);
+    }
+
+    /**
+    * 確認書対象の住民行を除外し、中間ファイル⑫を作成する処理
+    */
+    function generateMidfile12(columnIndices, header, rows) {
+        // 除外対象の世帯番号の値を収集するためのセットを作成する
+        const excludedHouseholdNumSet = new Set();
+        // 除外条件となる課税区分の値を定義する
+        const taxClass = ['1', '2', '4'];
+
+        // 課税区分が「1（非課税対象）」「2（均等割対象）」「4（未申告）」のいずれかであるかつ続柄１が「02（＝世帯主）」である行の「世帯番号」を収集する
+        rows.forEach((line) => {
+            if (taxClass.includes(line[columnIndices[23]]) && line[columnIndices[10]] === '02') {
+                excludedHouseholdNumSet.add(line[columnIndices[9]]);
+            }
+        });
+
+        // 除外対象の世帯番号に属する行を除外する処理
+        const filteredLines = rows.filter((line) => {
+            if (excludedHouseholdNumSet.has(line[columnIndices[9]])) {
+                // その世帯番号に属する全行を取得する
+                const householdLines = rows.filter((householdLine) => householdLine[columnIndices[9]] === line[columnIndices[9]]);
+                // その世帯のすべての行が課税区分が「1」「2」「4」のいずれかであるか確認する
+                if (householdLines.every((householdLine) => taxClass.includes(householdLine[columnIndices[23]]))) {
+                    // 条件に合致する（＝確認書の対象である）場合は除外する
+                    return false;
+                }
+            }
+            // 条件に合致しない場合は除外せずに保持し続ける
+            return true;
+        });
+
+        // フィルタリングされた行を再度カンマで結合し、改行で区切られた文字列に変換
+        return formatOutputFile(header, filteredLines, NEWLINE_CHAR_CRLF);
+    }
+}
+
+/**
+* 給付対象者ファイルの形式に整形する処理。直接振込or確認書は第三引数を使用することによって判断し、抽出条件を出し分ける。
+* @param {Array} columnIndices - カラムインデックスの配列
+* @param {Array} rows - 中間ファイルの行の配列
+* @param {String} benefitType - 給付形態を記載する。直接給付の場合は「push」確認書対象の場合は「confirmation」を設定する
+* @returns {String} 給付対象者ファイルの文字列
+*/
+function generateBeneficiaryfile(columnIndices, rows, benefitType) {
+    // 抽出対象世帯の世帯主行を格納するリストを定義する（直接給付、確認書の抽出処理両方で使用する）
+    let filteredLines = [];
+    // 最終的に出力する行を格納するリストを定義する
+    const outputLines = [];
+    // 性別カラムの変換時、中間ファイル内の性別コードが「1」「2」の場合にエラーを出力するため、エラー出力用のリストを定義する
+    const genderErrorAddressNums = [];
+    // 続柄カラムの変換時、中間ファイル⑦内の続柄１が空の場合にエラーを出力するため、エラー出力用のリストを定義する
+    const relationshipErrorAddressNums = [];
+    // 課税区分が「3」の場合、課税対象の住民（＝給付対象になりえない住民）が混ざっているということなので、エラーとして表示する。そのためのリストを定義する
+    const taxClassErrorAddressNums = [];
+    // 確認書対象抽出時の抽出条件である、課税区分（「1（非課税対象）」「2（均等割対象）」「4（未申告）」）を定義する
+    const taxClass = ['1', '2', '4'];
+    // 給付対象者ファイルのヘッダーを定義する
+    const beneficiaryFileHeader = [
+        '宛名番号',
+        '受給者宛名番号',
+        '氏名',
+        '氏名フリガナ',
+        '生年月日',
+        '性別',
+        '電話番号',
+        '郵便番号',
+        '住所',
+        '方書',
+        '異動元郵便番号',
+        '異動元住所',
+        '異動元方書',
+        '世帯番号',
+        '世帯主宛名番号',
+        '続柄',
+        '郵送対象者フラグ',
+        '通称名',
+        '通称名カナ',
+        'フォーマット種別',
+        '課税区分',
+        '住民カスタム属性',
+        '転入日',
+        '賦課期日居住者フラグ',
+        '照会対象フラグ',
+        '賦課無フラグ',
+        '課税保留フラグ',
+        '租税条約免除フラグ',
+        '生活扶助非課税フラグ',
+        '対象者_課税フラグ',
+        '対象者_市減免後均等割額',
+        '対象者_県減免後均等割額',
+        '扶養主_宛名番号',
+        '扶養主_課税フラグ',
+        '扶養主_市免除後均等割額',
+        '扶養主_県免除後均等割額',
+        '専従主_宛名番号',
+        '専従主_課税フラグ',
+        '専従主_市減免後均等割額',
+        '専従主_県減免後均等割額',
+        '生活扶助認定年月日',
+        '生活扶助廃止年月日',
+        '多子加算対象者フラグ'
+    ];
+
+    // 直接振込の場合の対象者抽出処理（口座名義カラム・口座番号カラムが空でない行（世帯主行）及び、世帯番号で紐づく世帯員行を抽出する）
+    if (benefitType === 'push') {
+        // 口座名義カラム・口座番号カラムが空でない（直接振込対象世帯の世帯主）行を抽出する
+        filteredLines = rows.filter(line => line[columnIndices[17]] && line[columnIndices[18]]);
+        // 口座名義カラム・口座番号カラムが空でない（直接振込対象世帯の世帯主）行毎に、宛名番号・世帯番号を取得後、出力用リストに追加する処理を行う
+        filteredLines.forEach(line => {
+            const addressNum = line[columnIndices[0]]; // 宛名番号を取得する
+            const householdNum = line[columnIndices[9]]; // 世帯番号を取得する
+
+            // 世帯主行を出力用リストに追加する。その際、「受給者宛名番号」は空に設定する
+            outputLines.push(createOutputLineForBeneficiaryFile(line, columnIndices, ''));
+
+            // 世帯番号をキーにして、世帯主以外の世帯員レコードを取得する
+            const householdMemberLines = rows.filter(otherLine => otherLine[columnIndices[9]] === householdNum && otherLine !== line);
+
+            // 世帯員の行を出力用リストに追加する。その際、「受給者宛名番号」に世帯主の宛名番号を設定する
+            householdMemberLines.forEach(line => {
+                outputLines.push(createOutputLineForBeneficiaryFile(line, columnIndices, addressNum));
+            });
+        });
+    }
+
+    // 確認書の場合の対象者抽出処理（課税区分が「1（非課税対象）」「2（均等割対象）」「4（未申告）」のいずれかである世帯主行及び、その世帯員行を抽出する）
+    else if (benefitType === 'confirmation') {
+        // 課税区分が「1（非課税対象）」「2（均等割対象）」「4（未申告）」のいずれかであるかつ続柄１が「02（世帯主）である行を抽出する
+        filteredLines = rows.filter(line => taxClass.includes(line[columnIndices[23]]) && line[columnIndices[10]] === '02');
+
+        // 抽出した行（世帯主行）毎に、宛名番号・世帯番号を取得する。
+        filteredLines.forEach(line => {
+            const addressNum = line[columnIndices[0]]; // 宛名番号を取得する
+            const householdNum = line[columnIndices[9]]; // 世帯番号を取得する
+
+            // 世帯番号をキーにして、世帯主以外の世帯員レコードを取得する
+            const householdMemberLines = rows.filter(otherLine => otherLine[columnIndices[9]] === householdNum && otherLine !== line);
+
+            // 取得した同世帯番号の全員の課税区分も「1（非課税対象）」「2（均等割対象）」「4（未申告）」のいずれかであるかを確認する
+            const isAllTaxClassMatched = householdMemberLines.every(householdMemberLine => taxClass.includes(householdMemberLine[columnIndices[23]]));
+
+            // 世帯全員が該当する場合のみ抽出対象世帯とし、後続処理を実行する
+            if (isAllTaxClassMatched) {
+                // 世帯主行を出力用リストに追加する。その際、「受給者宛名番号」は空に設定する
+                outputLines.push(createOutputLineForBeneficiaryFile(line, columnIndices, ''));
+
+                // 世帯員の行を出力用リストに追加する。その際、「受給者宛名番号」に世帯主の宛名番号を設定する
+                householdMemberLines.forEach(line => {
+                    outputLines.push(createOutputLineForBeneficiaryFile(line, columnIndices, addressNum));
+                });
+            }
+        });
+    }
+
+    /**
+     * 抽出後の行のうち必要なカラムのみを抽出し、出力用の行を作成する処理
+     * @param {Array} line - 出力用の行を作成する元となる行
+     * @param {Array} columnIndices - 出力用の行を作成する元となる行のカラムインデックス
+     * @param {String} addressNum - 出力用の行に設定する「受給者宛名番号」（世帯主の場合は空（''）、他世帯員の場合は世帯主の宛名番号を引数として設定する）
+     * @returns {Array} 必要なカラムのみを抽出し、出力用の行を作成した結果
+    */
+    function createOutputLineForBeneficiaryFile(line, columnIndices, addressNum) {
+        let semiProcessedAddressNum = addressNum;
+        // 引数「addressNum」が空でない場合、15桁の宛名番号に変換する
+        if (addressNum !== '') {
+            semiProcessedAddressNum = addressNum.toString().padStart(15, '0');
+        }
+        // 定数として定義しなおす
+        const processedAddressNum = semiProcessedAddressNum
+
+        // 性別コードを変換し、エラーがあればエラー出力用リストに対象の宛名番号を追加する
+        let genderCode = convertGenderCode(line[columnIndices[4]]);
+        if (genderCode === '') {
+            genderErrorAddressNums.push(line[columnIndices[0]]);
+        }
+
+        // 続柄コードを変換し、エラーがあればエラー出力用リストに対象の宛名番号を追加する
+        let relationshipCode = convertRelationshipCode(line[columnIndices[10]], line[columnIndices[11]], line[columnIndices[12]], line[columnIndices[13]]);
+        if (relationshipCode === '') {
+            relationshipErrorAddressNums.push(line[columnIndices[0]]);
+        }
+
+        // 多子加算対象住民に対してフラグを立てる（デフォルト値は「0（多子加算非対象）」を設定する）
+        let semiChildAmountFlg = '0';
+        // 日付比較用に、生年月日カラムの値をdate型にする
+        const birthDate = parseDate(line[columnIndices[3]]);
+        // 日付比較用に、H18(2006).4.2をdate型にする
+        const targetDate = new Date('2006-04-02 00:00:00');
+        // 多子加算判定を実施する（世帯主（続柄１が「02」）ではないかつ、生年月日がH18(2006).4.2以降である場合に多子加算対象者とする）
+        if (line[columnIndices[10]] !== '02' && birthDate >= targetDate) {
+            semiChildAmountFlg = '1';
+        }
+        // 定数として定義しなおす
+        const childAmountFlg = semiChildAmountFlg
+
+        // 通称名の使用有無を判断する処理（「外国人氏名優先区分」カラムに「3」が入力されている場合、通称名を入力する。デフォルト値は空）
+        let semiNickname = '';
+        let semiNicknameKana = '';
+        // 通称名の使用有無を判断する（「外国人氏名優先区分」カラムに「3」が入力されている場合、通称名を設定する）
+        if (line[columnIndices[22]] == '3') {
+            semiNickname = line[columnIndices[14]]; // 住基内「外国人通称名」カラムの値を入力
+            semiNicknameKana = line[columnIndices[15]]; // 住基内「外国人カナ通称名」カラムの値を入力
+        }
+        // 定数として定義しなおす
+        const nickname = semiNickname;
+        const nicknameKana = semiNicknameKana;
+
+        // インプット内「課税区分」の値を参照し、日本語化した文字列（「非課税対象」「均等割対象」）を、アウトプットの「住民カスタム属性」に出力する処理
+        const inputTaxClass = String(line[columnIndices[23]]); // 判定で数回使用するため、定数として定義しておく
+        let outputTaxClass = ''; // 出力用の変数を定義する
+
+        // インプットファイル内「続柄１」カラムの値が「02（＝世帯主）」である場合のみ、課税区分を判定する処理を行う
+        if (line[columnIndices[10]] === '02') {
+            // 以下、課税区分の値を参照し、日本語化した文字列を変数に格納する処理
+            if (inputTaxClass === '1') {
+                outputTaxClass = '非課税対象';
+            }
+            else if (inputTaxClass === '2') {
+                outputTaxClass = '均等割対象';
+            }
+            else if (inputTaxClass === '3') {
+                // 課税区分が「3」の場合、課税対象の住民（＝給付対象になりえない住民）が混ざっているということなので、エラーとして表示する
+                taxClassErrorAddressNums.push(line[columnIndices[0]]);
+            }
+            else if (inputTaxClass === '4') {
+                outputTaxClass = '未申告';
+            }
+        }
+
+        return [
+            // 以下、テンプレートのカラム  
+            line[columnIndices[0]].toString().padStart(15, '0'), // 宛名番号（15桁に変換する）
+            processedAddressNum, // 受給者宛名番号（世帯主の場合は空、他世帯員の場合は世帯主の宛名番号を15桁に変換した番号を設定する）
+            line[columnIndices[1]] || line[columnIndices[16]],// 漢字氏名（漢字氏名が無い場合は英字氏名を入力する）
+            line[columnIndices[2]], // カナ氏名
+            separateDate(line[columnIndices[3]], '/'), // 生年月日（「yyyy/mm/dd」形式に変換する）
+            genderCode, // 性別
+            excludeHyphen(line[columnIndices[5]]), // 電話番号（ハイフンを除去する）
+            excludeHyphen(line[columnIndices[6]]), // 郵便番号（ハイフンを除去する）
+            line[columnIndices[7]], // 住所
+            line[columnIndices[8]], // 方書
+            '', // 異動元郵便番号
+            '', // 異動元住所
+            '', // 異動元方書
+            line[columnIndices[9]].toString().padStart(15, '0'), // 世帯番号
+            '', // 世帯主宛名番号（世帯主行は空にする）
+            relationshipCode, // 続柄
+            '1', // 郵送対象者フラグ（郵送対象者のため「1」を設定）
+            nickname, // 外国人通称名
+            nicknameKana, // 外国人カナ通称名
+            '非課税均等割確認書', // フォーマット種別（固定値）
+            'R6S1SBS', // 課税区分（固定値）
+            outputTaxClass, // 住民カスタム属性（「課税区分」の値を参照し、日本語化した文字列を入力する）
+            // 以下、非課税・均等割特有のカラム
+            '', // 転入日
+            '', // 賦課期日居住者フラグ
+            '', // 照会対象フラグ
+            '', // 賦課無フラグ
+            '', // 課税保留フラグ
+            '', // 租税条約免除フラグ
+            '', // 生活扶助非課税フラグ
+            '', // 対象者_課税フラグ
+            '', // 対象者_市減免後均等割額
+            '', // 対象者_県減免後均等割額
+            '', // 扶養主_宛名番号
+            '', // 扶養主_課税フラグ
+            '', // 扶養主_市免除後均等割額
+            '', // 扶養主_県免除後均等割額
+            '', // 専従主_宛名番号
+            '', // 専従主_課税フラグ
+            '', // 専従主_市減免後均等割額
+            '', // 専従主_県減免後均等割額
+            '', // 生活扶助認定年月日
+            '', // 生活扶助廃止年月日
+            childAmountFlg // 多子加算対象者フラグ
+        ];
+    }
+
+    // 性別コードによるエラーがあれば例外を投げる
+    if (genderErrorAddressNums.length > 0) {
+        throw new Error('以下の住民の性別カラムに「1」「2」以外の値が入力されています。ファイルの確認をお願いします。\n' + genderErrorAddressNums.join('\n'))
+    }
+
+    // 続柄コードによるエラーがあれば例外を投げる
+    if (relationshipErrorAddressNums.length > 0) {
+        throw new Error('以下の住民の続柄１カラムが空です。ファイルの確認をお願いします。\n' + relationshipErrorAddressNums.join('\n'))
+    }
+
+    // 課税区分が「3（課税対象）」であることによるエラーがあれば例外を投げる
+    if (taxClassErrorAddressNums.length > 0) {
+        throw new Error('以下の住民は課税対象の住民です。ファイルの確認をお願いします。\n' + taxClassErrorAddressNums.join('\n'))
+    }
+
+    // 出力用リストをカンマで結合し、改行で区切られた文字列に変換
+    return formatOutputFile(beneficiaryFileHeader, outputLines, NEWLINE_CHAR_CRLF);
+}
+
+/**
+* 直接振込対象者ファイル（フラグ用ファイル）を作成する処理
+* @param {Array} columnIndices - カラムインデックスの配列
+* @param {Array} rows - 中間ファイルの行の配列
+* @param {String} benefitType - 給付形態を記載する。直接給付の場合は「push」確認書対象の場合は「confirmation」を設定する
+* @returns {String} 給付対象者ファイルの文字列
+*/
+function generatePushTargetfile(columnIndices, rows, benefitType) {
+    // 直接振込対象者フラグを定義する
+    let pushTargetFlag;
+    // 抽出した行を格納する変数を定義する
+    let filteredLines = [];
+    // 抽出対象の世帯番号の値を収集するためのセットを定義する
+    const beneficiaryHouseholdNumSet = new Set();
+    // 最終的に出力するカラム整形後データを格納するリストを定義する
+    const outputLines = [];
+    // 確認書対象抽出時の抽出条件である、課税区分（「1（非課税対象）」「2（均等割対象）」「4（未申告）」）を定義する
+    const taxClass = ['1', '2', '4'];
+    // 直接振込対象者ファイルのヘッダーを定義する
+    const pushTargetFileHeader = [
+        '宛名番号',
+        '直接振込対象者フラグ',
+        '課税区分キー',
+    ];
+
+    // 直接振込の場合の対象者抽出処理
+    if (benefitType === 'push') {
+        // 直接振込対象者フラグの値を「1（直接振込対象者）」に設定する
+        pushTargetFlag = '1';
+
+        // 名義人カラム・公金口座番号カラムが空でない（プッシュ対象世帯の世帯主）行の「世帯番号」を収集する
+        rows.forEach((line) => {
+            if (line[columnIndices[17]] && line[columnIndices[18]]) {
+                // 「世帯番号」の値をセットに追加する
+                beneficiaryHouseholdNumSet.add(line[columnIndices[9]]);
+            }
+        });
+
+        // 収集した世帯番号に属する行（対象世帯員全員）を抽出する
+        filteredLines = rows.filter((line) => {
+            return beneficiaryHouseholdNumSet.has(line[columnIndices[9]]);
+        });
+    }
+
+    // 確認書対象の場合の対象者抽出処理（及び、その世帯員行を抽出する）
+    else if (benefitType === 'confirmation') {
+        // 直接振込対象者フラグの値を「0（プッシュ対象者として設定しない）」に設定する
+        pushTargetFlag = '0';
+
+        // 課税区分が「1（非課税対象）」「2（均等割対象）」「4（未申告）」のいずれかであるかつ続柄１が「02（＝世帯主）」である行の「世帯番号」を収集する
+        rows.forEach((line) => {
+            if (taxClass.includes(line[columnIndices[23]]) && line[columnIndices[10]] === '02') {
+                // 「世帯番号」の値をセットに追加する
+                beneficiaryHouseholdNumSet.add(line[columnIndices[9]]);
+            }
+        });
+
+        filteredLines = rows.filter((line) => {
+            // 収集した世帯番号に属する行のみ後続処理を行う
+            if (beneficiaryHouseholdNumSet.has(line[columnIndices[9]])) {
+                // その世帯番号に属する全行を取得する
+                const householdLines = rows.filter((householdLine) => householdLine[columnIndices[9]] === line[columnIndices[9]]);
+                // その世帯のすべての行が課税区分が「1」「2」「4」のいずれかであるか確認
+                return householdLines.every((householdLine) => taxClass.includes(householdLine[columnIndices[23]]));
+            }
+            // 条件に合わない行は抽出対象から除外する
+            return false;
+        });
+    }
+
+    // 抽出した行のうち必要なカラムのみ出力用リストに追加する
+    filteredLines.forEach(line => {
+        outputLines.push([
+            line[columnIndices[0]].toString().padStart(15, '0'), // 宛名番号
+            pushTargetFlag, // 直接振込対象者フラグ
+            'R6S1SBS' // 課税区分キー（固定値「R6S1SBS」）
+        ]);
+    });
+
+    // フィルタリングされた行を再度カンマで結合し、改行で区切られた文字列に変換
+    return formatOutputFile(pushTargetFileHeader, outputLines, NEWLINE_CHAR_CRLF);
+}
 
 /* 以下、使いまわすメソッド（汎用処理）ここから */
 


### PR DESCRIPTION
### ■概要
STEP15（確認書対象者をSNにインポートする形式のファイルとして出力する処理）を実装しました。
また、STEP15の開発にあたりSTEP10（プッシュ対象者をSNにインポートする形式のファイルとして出力する処理）を改修しましたので、下記に記載します。
※処理自体はほとんど変更していないのですが、functionを使いまわすためにSTEP10のプライベートfunctionからグローバルfunctionにしました。
　それによっていくつか調整が入った形になります。


### ■新規開発function：generateFilesforConfirmationTargetImport
STEP15に対応するfunctionで、「SNにインポートする住民情報ファイル」「SNにインポートするプッシュ対象者ファイル（今回は確認書対象のため一律でプッシュ対象者に設定しない）」「税情報無しの住民ファイル」「中間ファイル⑫」の4ファイルをアウトプットします。
本functionはそれぞれの処理を呼び出す大元のfunctionとなります。それぞれの処理は差分でご確認いただければと思います。
基本的にSTEP10の処理を参考にして作成しました。


### ■改修した既存function：generateBeneficiaryfile、generatePushTargetfile
SNにインポートする「住民情報ファイル」「プッシュ対象者ファイル」を作成する処理になります。
もともとはどちらもSTEP10のプライベートfunctionとして実装していましたが、STEP15で出力するファイルが仕様が同じであるため、使いまわしたいと思いグローバルfunction化しました。
念のため、STEP10の方は改修前のコード（グローバル化する前のコード）をコメントアウトで残しておきました、RVが通り次第消す予定です。
クローバル化に伴い、以下の点に関して処理を追加しました。

・抽出条件の出し分け
プッシュ対象者の抽出、確認書対象者の抽出は条件が異なるため、そのままグローバル化は出来ませんでした。そのためどちらのfunctionでも第三引数として「benefitType」を作成し、その値に応じて抽出処理を出し分けることにしました。
・グローバル定数の定義場所移動
[こちら](https://github.com/doy1022/ConvertTool/pull/96)のブランチにて、出力するファイルのヘッダーをグローバル定数化しましたが、今回改修した2処理でしか使用しないため、それぞれgenerateBeneficiaryfile、generatePushTargetfile内で宣言するように戻しました。

以上、よろしくお願いいたします。