### PR TITLE
20240729 doiguchi 1

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,15 +223,15 @@
                     <button type="button" onclick="updateTaxInfoByReInquiryResult()">中間ファイル⑪を作成する</button>
                 </form>-->
 
-                <h1>15.下記の4ファイルを作成する</h1>
+                <h1>14.下記の4ファイルを作成する</h1>
                 <ul>
                     <li>ServiceNowにインポートする「給付対象者ファイル」</li>
                     <li>ServiceNowにインポートする「直接振込対象者ファイル」</li>
                     <li>税情報不明住民リスト</li>
-                    <li>中間ファイル⑫</li>
+                    <li>中間ファイル⑪</li>
                 </ul>
                 <form id="csvForm22">
-                    <label for="file33">中間ファイル⑪をアップロードしてください:</label>
+                    <label for="file33">中間ファイル⑩をアップロードしてください:</label>
                     <input type="file" id="file33" accept=".csv"><br><br>
                     <button type="button" onclick="generateFilesforConfirmationTargetImport()">上記4ファイルを作成する</button>
                 </form>

--- a/index.html
+++ b/index.html
@@ -204,23 +204,24 @@
                     <button type="button" onclick="updateTaxInfoByNumLinkageErrorResidentsFile()">中間ファイル⑩_番号連携エラー取込み済み を作成する</button>
                 </form>
 
-                <h1>追加対応4.中間ファイルの「所得割額」の値を「金額予備１０」の値で更新する</h1>
+                <h1>追加対応4.中間ファイルの「所得割額」の値を「金額予備１０」の値で更新する<br>
+                ※事前に追加対応1を実施し、最新の税情報マスタを作成してから本STEPを実施してください。</h1>
                 <form id="csvForm24">
                     <label for="file41">中間ファイル⑩をアップロードしてください:</label>
                     <input type="file" id="file41" accept=".csv"><br><br>
                     <label for="file42">税情報マスタをアップロードしてください:</label>
                     <input type="file" id="file42" accept=".csv"><br><br>
-                    <button type="button" onclick="additionalExclusion()">中間ファイル⑩_「金額予備１０」対応済み を作成する</button>
+                    <button type="button" onclick="amountReserveSupport()">中間ファイル⑩_「金額予備１０」対応済み を作成する</button>
                 </form>
 
-                <h1>14.番号連携照会結果（税情報）ファイルから課税区分を判別し、中間ファイルを更新する</h1>
+                <!--<h1>14.番号連携照会結果（税情報）ファイルから課税区分を判別し、中間ファイルを更新する</h1>
                 <form id="csvForm21">
                     <label for="file31">中間ファイル⑩をアップロードしてください:</label>
                     <input type="file" id="file31" accept=".csv"><br><br>
                     <label for="file32">番号連携照会結果（税情報）ファイルをアップロードしてください:</label>
                     <input type="file" id="file32" accept=".DAT"><br><br>
                     <button type="button" onclick="updateTaxInfoByReInquiryResult()">中間ファイル⑪を作成する</button>
-                </form>
+                </form>-->
 
                 <h1>15.下記の4ファイルを作成する</h1>
                 <ul>

--- a/styles.css
+++ b/styles.css
@@ -28,6 +28,11 @@
     border-radius: 5px;
 }
 
+h1 {
+    color: #1b85db;
+    font-size: 1.5rem;
+}
+
 body {
     font-family: "Helvetica Neue",
       Arial,
@@ -106,7 +111,7 @@ input:checked + .tab {
     padding: 1em;
     position: relative;
     z-index: 0;
-    background-color: #fff;
+    background-color: #fafafa;
     border-radius: 0 0 0.5em 0.5em;
     animation: fadeIn 0.5s;
 }


### PR DESCRIPTION
### ■概要
追加対応STEP4（税情報マスタの「金額予備１０」の値を参照し、課税区分を再判定する処理。「金額予備１０」に値が無い（＝賦課マスタではなく番号連携によって税情報が発覚した住民）行に関しては、税情報マスタの「金額予備１０」の代わりに「所得割額」の値を使用する）の処理を実装しました。


### ■新規開発function：amountReserveSupport
実際に上記「概要」の処理を行うfunction「updateTaxInfoFromAmountReserveColumn」と、課税住民及びその世帯員を除外するfunction「filterTaxExcluded」を呼び出す、大元のfunctionになります。
処理詳細は差分で実際のコードを確認していただけると幸いです


### ■その他改修部
本ブランチで主に実装している追加対応STEP4の箇所とは別で、「generateFilesforConfirmationTargetImport」functionも数箇所軽微な改修を入れました。
というのも、追加対応STEP4の実装期間中にSTEP14が廃止され、STEP15が繰り上げでSTEP14となったため、
・コメントアウトなどで記載されていた「STEP15」→「STEP14」に修正
・入力ファイルを「中間ファイル⑪」→「中間ファイル⑩」に修正
・出力ファイルを「中間ファイル⑫」→「中間ファイル⑪」に修正
など、各繰り上げ修正対応を実施しました（ブランチを分けるべきでした、すみません）

以上、よろしくお願いいたします。