### PR TITLE
20240731 doiguchi 1

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,7 +182,7 @@
                     <input type="file" id="file27" accept=".csv"><br><br>
                     <label for="file28">現宛名番号の住民票コードに紐づく旧宛名番号ファイルをアップロードして下さい:</label>
                     <input type="file" id="file28" accept=".csv"><br><br>
-                    <label for="file29">賦課マスタをアップロードして下さい:</label>
+                    <label for="file29">税情報マスタをアップロードして下さい:</label>
                     <input type="file" id="file29" accept=".csv"><br><br>
                     <button type="button" onclick="determineTaxClassfromOldAddressNum()">中間ファイル⑩を作成する</button>
                 </form>


### PR DESCRIPTION
STEP12（「「番号連携エラー住民のうち、照会が完了している住民一覧」ファイル」のデータと「税情報マスタ」を参照し、中間ファイル⑨の税情報を更新する処理）のメイン実装を行ったブランチとなります。数箇所まだ直したい箇所があるのですが、日を跨いでキリが悪い為、ここで一旦切り上げブランチを変えて作業します。

### ■実装したfunction：determineTaxClassfromOldAddressNum
STEP12対応の処理となります。条件分岐が多く、全体的に処理のネストが深くなっているのが個人的に気持ち悪いと感じております（要件上致し方ないかとは思いますが…）
下記に要件を記載いたします。

---------------------------------------------------------------
「「番号連携エラー住民のうち、照会が完了している住民一覧」ファイル」に関して

■同住民表コードで、E列「消除フラグ」が「現存者」「消除者」のどちらのデータも存在する住民について
　基準となる日（20240101）より後に住民登録をした方が「現存者」となっており、その宛名番号に紐づく税情報がない状態である。
　「消除者」レコードのうち、 「住民日」が基準となる日（20240101）以前かつ一番新しいレコード  に紐づく税情報をその住民の税情報とし、課税判定を行う。

■E列「消除フラグ」が「現存者」となっているデータのみで、同住民表コードの「消除者」データが無い住民について
　国内住登録無し（＝未申告）として扱う

■E列「消除フラグ」が「消除者」となっているデータのみで、同住民表コードの「現存者」データが無い住民について
　F列「消除日」を確認し、「20240603」以前であれば給付対象外として除外する
　除外対象でない場合、過去宛名番号があればその税情報を使用し、なければ国内住登録無し（＝未申告）として扱う

---------------------------------------------------------------
